### PR TITLE
Account for scroll of offset parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.0.7
+
+- Fix `getCoords` to account for an element inside a relative parent, which has _been scrolled_.
+
 ## 6.0.6
 
 - Upgrade dependencies

--- a/assets/playground.html
+++ b/assets/playground.html
@@ -68,16 +68,10 @@
         var element = document.querySelector('.element');
         var reference = document.querySelector('.reference');
         var getCoords = window.positionUtils.getCoords;
-
-        var coords = getCoords('bottom left', element, reference);
-
-        console.log(coords);
-        console.log(element);
+        var coords = getCoords('top left', element, reference);
 
         element.style.left = coords[0] + 'px';
         element.style.top = coords[1] + 'px';
-
-        console.log(element.style.left);
       }
 
       document.querySelector('.position').addEventListener('click', position);

--- a/assets/playground.html
+++ b/assets/playground.html
@@ -51,8 +51,6 @@
   </head>
   <body>
     <div class="space"></div>
-    <div class="space"></div>
-    <div class="space"></div>
 
     <div class="container">
       <div class="space"></div>
@@ -61,8 +59,6 @@
       <div class="space"></div>
     </div>
 
-    <div class="space"></div>
-    <div class="space"></div>
     <div class="space"></div>
 
     <button class="position" type="button">Position</button>
@@ -73,10 +69,15 @@
         var reference = document.querySelector('.reference');
         var getCoords = window.positionUtils.getCoords;
 
-        var coords = getCoords('top left', element, reference);
+        var coords = getCoords('bottom left', element, reference);
+
+        console.log(coords);
+        console.log(element);
 
         element.style.left = coords[0] + 'px';
         element.style.top = coords[1] + 'px';
+
+        console.log(element.style.left);
       }
 
       document.querySelector('.position').addEventListener('click', position);

--- a/index.js
+++ b/index.js
@@ -59,76 +59,6 @@
     return position.join(' ');
   }
 
-  function getPositionForRect(position, rect, referenceRect) {
-    var point = getMiddleOfRect(referenceRect);
-    var center = point[0] - rect.width / 2;
-    var middle = point[1] - rect.height / 2;
-    var top = referenceRect.top - rect.height;
-    var left = referenceRect.left - rect.width;
-    var bottom = referenceRect.top + referenceRect.height;
-    var right = referenceRect.left + referenceRect.width;
-    var x;
-    var y;
-
-    switch (position) {
-      case 'top left':
-        x = left + rect.width;
-        y = top;
-        break;
-      case 'top center':
-        x = center;
-        y = top;
-        break;
-      case 'top right':
-        x = right - rect.width;
-        y = top;
-        break;
-      case 'right top':
-        x = right;
-        y = top + rect.height;
-        break;
-      case 'right middle':
-        x = right;
-        y = middle;
-        break;
-      case 'right bottom':
-        x = right;
-        y = bottom - rect.height;
-        break;
-      case 'bottom left':
-        x = left + rect.width;
-        y = bottom;
-        break;
-      case 'bottom center':
-        x = center;
-        y = bottom;
-        break;
-      case 'bottom right':
-        x = right - rect.width;
-        y = bottom;
-        break;
-      case 'left top':
-        x = left;
-        y = top + rect.height;
-        break;
-      case 'left middle':
-        x = left;
-        y = middle;
-        break;
-      case 'left bottom':
-        x = left;
-        y = bottom - rect.height;
-        break;
-    }
-
-    return {
-      top: y,
-      left: x,
-      right: x + rect.width,
-      bottom: y + rect.height
-    };
-  }
-
   function getPosition(element, container, columns, rows) {
     var elementRect = element.getBoundingClientRect();
     var containerRect = getNormalisedRect(container);
@@ -158,11 +88,75 @@
     var elementRect = element.getBoundingClientRect();
     var referenceRect = reference.getBoundingClientRect();
     var offsetRect = element.offsetParent.getBoundingClientRect();
-    var positionRect = getPositionForRect(position, elementRect, referenceRect);
-    var scrollLeft = offsetRect.left * -1;
-    var scrollTop = offsetRect.top * -1;
-    var y = positionRect.top + scrollTop;
-    var x = positionRect.left + scrollLeft;
+    var elementHeight = elementRect.height;
+    var elementWidth = elementRect.width;
+    var point = getMiddleOfRect(referenceRect);
+    var referenceCenter = point[0] - elementWidth / 2;
+    var referenceMiddle = point[1] - elementHeight / 2;
+    var referenceTop = referenceRect.top;
+    var referenceLeft = referenceRect.left;
+    var referenceRight = referenceLeft + referenceRect.width;
+    var referenceBottom = referenceTop + referenceRect.height;
+    var offsetScrollTop = element.offsetParent.scrollTop;
+    var offsetScrollLeft = element.offsetParent.scrollLeft;
+    var offsetTop = offsetRect.top * -1;
+    var offsetLeft = offsetRect.left * -1;
+    var x;
+    var y;
+
+    switch (position) {
+      case 'top left':
+        x = referenceLeft;
+        y = referenceTop - elementHeight;
+        break;
+      case 'top center':
+        x = referenceCenter;
+        y = referenceTop - elementHeight;
+        break;
+      case 'top right':
+        x = referenceRight - elementWidth;
+        y = referenceTop - elementHeight;
+        break;
+      case 'right top':
+        x = referenceRight;
+        y = referenceTop;
+        break;
+      case 'right middle':
+        x = referenceRight;
+        y = referenceMiddle;
+        break;
+      case 'right bottom':
+        x = referenceRight;
+        y = referenceBottom - elementHeight;
+        break;
+      case 'bottom left':
+        x = referenceLeft;
+        y = referenceBottom;
+        break;
+      case 'bottom center':
+        x = referenceCenter;
+        y = referenceBottom;
+        break;
+      case 'bottom right':
+        x = referenceRight - elementWidth;
+        y = referenceBottom;
+        break;
+      case 'left top':
+        x = referenceLeft - elementWidth;
+        y = referenceTop;
+        break;
+      case 'left middle':
+        x = referenceLeft - elementWidth;
+        y = referenceMiddle;
+        break;
+      case 'left bottom':
+        x = referenceLeft - elementWidth;
+        y = referenceBottom - elementHeight;
+        break;
+    }
+
+    x += offsetLeft + offsetScrollLeft;
+    y += offsetTop + offsetScrollTop;
 
     return [x, y];
   }

--- a/test.js
+++ b/test.js
@@ -11,13 +11,23 @@ class Node {
   }
 }
 
-class Window {}
-class Document {}
+class Window {
+  constructor(width, height) {
+    this.innerWidth = width;
+    this.innerHeight = height;
+  }
+}
+
+class Document {
+  constructor(element) {
+    this.documentElement = element;
+  }
+}
 
 global.Window = Window;
 global.Document = Document;
 
-test('#getPosition', (t) => {
+test('get position of element in container', (t) => {
   const container = new Node({
     top: 10,
     left: 20,
@@ -27,54 +37,126 @@ test('#getPosition', (t) => {
     bottom: 160
   });
 
-  let element;
+  const window = new Window(300, 150);
 
-  element = new Node({ top: 47, left: 99, width: 40, height: 25 });
-  t.is(getPosition(element, container, 3, 3), 'top left');
+  const document = new Document(container);
 
-  element = new Node({ top: 47, left: 100, width: 40, height: 25 });
-  t.is(getPosition(element, container, 3, 3), 'top center');
+  const topLeftElement = new Node({
+    top: 47,
+    left: 99,
+    width: 40,
+    height: 25
+  });
 
-  element = new Node({ top: 47, left: 201, width: 40, height: 25 });
-  t.is(getPosition(element, container, 3, 3), 'top right');
+  const topCenterElement = new Node({
+    top: 47,
+    left: 100,
+    width: 40,
+    height: 25
+  });
 
-  element = new Node({ top: 48, left: 99, width: 40, height: 25 });
-  t.is(getPosition(element, container, 3, 3), 'middle left');
+  const topRightElement = new Node({
+    top: 47,
+    left: 201,
+    width: 40,
+    height: 25
+  });
 
-  element = new Node({ top: 48, left: 100, width: 40, height: 25 });
-  t.is(getPosition(element, container, 3, 3), 'middle center');
+  const middleLeftElement = new Node({
+    top: 48,
+    left: 99,
+    width: 40,
+    height: 25
+  });
 
-  element = new Node({ top: 48, left: 201, width: 40, height: 25 });
-  t.is(getPosition(element, container, 3, 3), 'middle right');
+  const middleCenterElement = new Node({
+    top: 48,
+    left: 100,
+    width: 40,
+    height: 25
+  });
 
-  element = new Node({ top: 98, left: 99, width: 40, height: 25 });
-  t.is(getPosition(element, container, 3, 3), 'bottom left');
+  const middleRightElement = new Node({
+    top: 48,
+    left: 201,
+    width: 40,
+    height: 25
+  });
 
-  element = new Node({ top: 98, left: 100, width: 40, height: 25 });
-  t.is(getPosition(element, container, 3, 3), 'bottom center');
+  const bottomLeftElement = new Node({
+    top: 98,
+    left: 99,
+    width: 40,
+    height: 25
+  });
 
-  element = new Node({ top: 98, left: 201, width: 40, height: 25 });
-  t.is(getPosition(element, container, 3, 3), 'bottom right');
+  const bottomCenterElement = new Node({
+    top: 98,
+    left: 100,
+    width: 40,
+    height: 25
+  });
+
+  const bottomRightElement = new Node({
+    top: 98,
+    left: 201,
+    width: 40,
+    height: 25
+  });
+
+  // All possible positions
+  t.is(getPosition(topLeftElement, container, 3, 3), 'top left');
+  t.is(getPosition(topCenterElement, container, 3, 3), 'top center');
+  t.is(getPosition(topRightElement, container, 3, 3), 'top right');
+  t.is(getPosition(middleLeftElement, container, 3, 3), 'middle left');
+  t.is(getPosition(middleCenterElement, container, 3, 3), 'middle center');
+  t.is(getPosition(middleRightElement, container, 3, 3), 'middle right');
+  t.is(getPosition(bottomLeftElement, container, 3, 3), 'bottom left');
+  t.is(getPosition(bottomCenterElement, container, 3, 3), 'bottom center');
+  t.is(getPosition(bottomRightElement, container, 3, 3), 'bottom right');
+
+  // Different position expectations
+  t.is(getPosition(topRightElement, container, 6, 3), 'top center');
+  t.is(getPosition(topRightElement, container, 3, 6), 'middle right');
+
+  // Special arguments where a container is derived
+  t.is(getPosition(bottomRightElement, window, 3, 3), 'bottom right');
+  t.is(getPosition(bottomRightElement, document, 3, 3), 'bottom right');
 });
 
 test('getCoords', (t) => {
-  const offsetParent = new Node({ top: -5, left: -10 });
-  const reference = new Node({ top: 25, left: 30, width: 20, height: 10 });
-  const element = new Node({ width: 40, height: 30 });
-  offsetParent.scrollTop = 0;
-  offsetParent.scrollLeft = 0;
-  element.offsetParent = offsetParent;
+  const reference = new Node({
+    top: 25,
+    left: 30,
+    width: 20,
+    height: 10
+  });
 
-  t.deepEqual(getCoords('top left', element, reference), [40, 0]);
-  t.deepEqual(getCoords('top center', element, reference), [30, 0]);
-  t.deepEqual(getCoords('top right', element, reference), [20, 0]);
-  t.deepEqual(getCoords('right top', element, reference), [60, 30]);
-  t.deepEqual(getCoords('right middle', element, reference), [60, 20]);
-  t.deepEqual(getCoords('right bottom', element, reference), [60, 10]);
-  t.deepEqual(getCoords('bottom left', element, reference), [40, 40]);
-  t.deepEqual(getCoords('bottom center', element, reference), [30, 40]);
-  t.deepEqual(getCoords('bottom right', element, reference), [20, 40]);
-  t.deepEqual(getCoords('left top', element, reference), [0, 30]);
-  t.deepEqual(getCoords('left middle', element, reference), [0, 20]);
-  t.deepEqual(getCoords('left bottom', element, reference), [0, 10]);
+  const element = new Node({
+    width: 40,
+    height: 30
+  });
+
+  const container = new Node({
+    top: -5,
+    left: -10
+  });
+
+  container.scrollTop = 4;
+  container.scrollLeft = 6;
+
+  element.offsetParent = container;
+
+  t.deepEqual(getCoords('top left', element, reference), [46, 4]);
+  t.deepEqual(getCoords('top center', element, reference), [36, 4]);
+  t.deepEqual(getCoords('top right', element, reference), [26, 4]);
+  t.deepEqual(getCoords('right top', element, reference), [66, 34]);
+  t.deepEqual(getCoords('right middle', element, reference), [66, 24]);
+  t.deepEqual(getCoords('right bottom', element, reference), [66, 14]);
+  t.deepEqual(getCoords('bottom left', element, reference), [46, 44]);
+  t.deepEqual(getCoords('bottom center', element, reference), [36, 44]);
+  t.deepEqual(getCoords('bottom right', element, reference), [26, 44]);
+  t.deepEqual(getCoords('left top', element, reference), [6, 34]);
+  t.deepEqual(getCoords('left middle', element, reference), [6, 24]);
+  t.deepEqual(getCoords('left bottom', element, reference), [6, 14]);
 });

--- a/test.js
+++ b/test.js
@@ -2,9 +2,8 @@ const test = require('ava');
 const { getPosition, getCoords } = require('./index');
 
 class Node {
-  constructor(rect, offsetParent) {
+  constructor(rect) {
     this.rect = rect;
-    this.offsetParent = offsetParent;
   }
 
   getBoundingClientRect() {
@@ -61,7 +60,10 @@ test('#getPosition', (t) => {
 test('getCoords', (t) => {
   const offsetParent = new Node({ top: -5, left: -10 });
   const reference = new Node({ top: 25, left: 30, width: 20, height: 10 });
-  const element = new Node({ width: 40, height: 30 }, offsetParent);
+  const element = new Node({ width: 40, height: 30 });
+  offsetParent.scrollTop = 0;
+  offsetParent.scrollLeft = 0;
+  element.offsetParent = offsetParent;
 
   t.deepEqual(getCoords('top left', element, reference), [40, 0]);
   t.deepEqual(getCoords('top center', element, reference), [30, 0]);


### PR DESCRIPTION
The current code for getting the coordinates to position an element next to reference element was not taking into consideration the amount the reference element's parent had been scrolled.